### PR TITLE
Move overlay down during SquidFest to not overlap squid count

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,6 +1,11 @@
 
 # Release Notes
 
+## Version 2.6.2
+
+* Move the overlay down during SquidFest so it does not
+  overlap with the squid count display.
+
 ## Version 2.6.1
 
 * Improved Vietnamese translation from GitHub user bl205vn

--- a/ToDew/ToDoOverlay.cs
+++ b/ToDew/ToDoOverlay.cs
@@ -231,7 +231,9 @@ namespace ToDew {
             {
                 int adjust = Game1.uiMode ? (int)MathF.Ceiling(80f * Game1.options.zoomLevel / Game1.options.uiScale) : 80;
                 effectiveBounds.Y = Math.Max(effectiveBounds.Y, adjust);
-            } else if (Game1.currentLocation is DesertFestival) {
+            } else if (Game1.currentLocation is DesertFestival 
+                || (Game1.IsWinter && Game1.dayOfMonth >= 12 && Game1.dayOfMonth <= 13 && Game1.currentLocation is Beach))
+            {
                 int adjust = Game1.uiMode ? (int)MathF.Ceiling(104f * Game1.options.zoomLevel / Game1.options.uiScale) : 104;
                 effectiveBounds.Y = Math.Max(effectiveBounds.Y, adjust);
             }


### PR DESCRIPTION
This applies the same fix as https://github.com/jltaylor-us/StardewToDew/commit/8d33ee1cca31070c33d38483bed92922d534cc98 to SquidFest.